### PR TITLE
Usage of full relative path in NUnitFiles

### DIFF
--- a/src/NuGetPsake.NUnit/NuGetPsakeModule.ps1
+++ b/src/NuGetPsake.NUnit/NuGetPsakeModule.ps1
@@ -12,7 +12,13 @@ task TestNUnit {
     if(-not $fullTestFileName.endswith('.dll') -and -not $fullTestFileName.endswith('.exe')){
       $fullTestFileName = $testFile + '.dll'
     }
-    $testFilePath = join-path $solutionDir (Get-ChildItem $solutionDir -Name $fullTestFileName -Recurse)[0]
+    
+    # if the testFile name contains \ assume it is a full relative path from the solutionDir
+    if($fullTestFileName.Contains("\")) {
+      $testFilePath = join-path $solutionDir $fullTestFileName
+    } else {
+      $testFilePath = join-path $solutionDir (Get-ChildItem $solutionDir -Name $fullTestFileName -Recurse)[0]
+    }
 
     if($isRunningOnBuildServer){
       & $teamcity['teamcity.dotnet.nunitlauncher'] v4.0 x86 NUnit-2.6.2 $testFilePath


### PR DESCRIPTION
Du får den lige den her vej Emil :) der var jo problemer med stierne, det skyldes at et af projekterne i solutionen havde en reference til test projektet og .Test.dll'en så lå i den mappe (fx. \bin\Debug) og den blev fundet så først :) Ved ikke om dette er den rigtige løsning, men det virker.
